### PR TITLE
Added Shared Boundary Policy for Drones Case Study

### DIFF
--- a/example/incrementalDrones/pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd.erte
+++ b/example/incrementalDrones/pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd.erte
@@ -1,0 +1,214 @@
+function pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd;
+interface of pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd {
+	in uint8_t x, y, x2, y2;
+	in uint16_t rpm, rpm2;
+	out uint8_t x_up, x_down, y_up, y_down, rpm_up, rpm_down; //out here means that they're going from CONTROLLER to PLANT
+	out uint8_t x2_up, x2_down, y2_up, y2_down, rpm2_up, rpm2_down;
+}
+
+policy ps of pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd {
+	states {
+        
+		l0 {
+			-> l0 on ((!x_down && x_up)) && ((y_down && !y_up));
+			-> l0 on ((!x_down && x_up)) && ((!y_down && y_up));
+			-> l0 on ((!x_down && x_up)) && ((!y_down && !y_up));
+			-> l0 on ((x_down && !x_up)) && ((y_down && !y_up));
+			-> l0 on ((x_down && !x_up)) && ((!y_down && y_up));
+			-> l0 on ((x_down && !x_up)) && ((!y_down && !y_up));
+			-> l0 on ((!x_down && !x_up)) && ((y_down && !y_up));
+			-> l0 on ((!x_down && !x_up)) && ((!y_down && y_up));
+			-> l0 on ((!x_down && !x_up)) && ((!y_down && !y_up));
+			-> violation on (x_down && x_up) recover x_up:= 0;
+			-> violation on (y_down && y_up) recover y_up:= 0;
+		}
+
+	}
+}
+
+policy pb of pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd {
+	internals {
+		constant uint8_t min_x := 0; 
+		constant uint8_t max_x := 2; 
+		constant uint8_t min_y := 200; 
+		constant uint8_t max_y := 202; 
+	}
+	states {
+        
+		b0 {
+			-> b0 on ((x_down && x >= min_x)) && ((y_down && y >= min_y));
+			-> b0 on ((x_down && x >= min_x)) && ((!y_down && !y_up));
+			-> b0 on ((x_down && x >= min_x)) && ((y_up && y < max_y));
+			-> b0 on ((!x_down && !x_up)) && ((y_down && y >= min_y));
+			-> b0 on ((!x_down && !x_up)) && ((!y_down && !y_up));
+			-> b0 on ((!x_down && !x_up)) && ((y_up && y < max_y));
+			-> b0 on ((x_up && x < max_x)) && ((y_down && y >= min_y));
+			-> b0 on ((x_up && x < max_x)) && ((!y_down && !y_up));
+			-> b0 on ((x_up && x < max_x)) && ((y_up && y < max_y));
+			-> violation on (x_down && x <= min_x) recover x_down:= 0;
+			-> violation on (x_up && x >= max_x) recover x_up:= 0;
+			-> violation on (y_down && y <= min_y) recover y_down:= 0;
+			-> violation on (y_up && y >= max_y) recover y_up:= 0;
+		}
+
+	}
+}
+
+policy pj of pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd {
+	internals {
+		constant uint8_t threshold := 5; 
+		constant uint8_t pj_min_y := 200; 
+		dtimer_t v1;
+	}
+
+	states {
+        
+		l0 {
+			-> l0 on (!x_up && !y_up && !rpm_up);
+			-> l1 on (x_up || y_up || rpm_up): v1 := 0;
+		}
+
+		l1 {
+			-> l1 on (x_up || x_down || y_up || (y_down && v1 <= threshold) || rpm_up || rpm_down): v1 := 0;
+			-> l1 on (!x_up && !x_down && !y_up && !y_down && v1 <= threshold && !rpm_up && !rpm_down);
+			-> l2 on (y_down && v1 > threshold);
+			-> violation on (v1 > threshold) recover y_down := 1;
+		}
+
+		l2 {
+			-> l2 on (y_down && y > pj_min_y);
+			-> violation on (!y_down && y > pj_min_y) recover y_down := 1;
+			-> l0 on (y <= pj_min_y);
+		}
+
+	}
+}
+
+policy pr of pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd {
+	internals {
+		constant uint16_t max_rpm := 7825; 
+	}
+	states {
+        
+		r0 {
+			-> r0 on ((rpm_up && rpm >= max_rpm));
+			-> r0 on ((!rpm_up || rpm_down));
+			-> violation on (rpm_up && x >= max_rpm) recover rpm_up := 0;
+			-> violation on ((rpm_up && rpm_down)) recover rpm_up := 0;
+		}
+
+	}
+}
+
+policy ps2 of pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd {
+	states {
+        
+		l0 {
+			-> l0 on ((!x2_down && x2_up)) && ((y2_down && !y2_up));
+			-> l0 on ((!x2_down && x2_up)) && ((!y2_down && y2_up));
+			-> l0 on ((!x2_down && x2_up)) && ((!y2_down && !y2_up));
+			-> l0 on ((x2_down && !x2_up)) && ((y2_down && !y2_up));
+			-> l0 on ((x2_down && !x2_up)) && ((!y2_down && y2_up));
+			-> l0 on ((x2_down && !x2_up)) && ((!y2_down && !y2_up));
+			-> l0 on ((!x2_down && !x2_up)) && ((y2_down && !y2_up));
+			-> l0 on ((!x2_down && !x2_up)) && ((!y2_down && y2_up));
+			-> l0 on ((!x2_down && !x2_up)) && ((!y2_down && !y2_up));
+			-> violation on (x2_down && x2_up) recover x2_up:= 0;
+			-> violation on (y2_down && y2_up) recover y2_up:= 0;
+		}
+
+	}
+}
+
+policy pb2 of pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd {
+	internals {
+		constant uint8_t min_x2 := 3; 
+		constant uint8_t max2_x2 := 5; 
+		constant uint8_t min_y2 := 200; 
+		constant uint8_t max2_y2 := 202; 
+	}
+	states {
+        
+		b0 {
+			-> b0 on ((x2_down && x2 >= min_x2)) && ((y2_down && y2 >= min_y2));
+			-> b0 on ((x2_down && x2 >= min_x2)) && ((!y2_down && !y2_up));
+			-> b0 on ((x2_down && x2 >= min_x2)) && ((y2_up && y2 < max2_y2));
+			-> b0 on ((!x2_down && !x2_up)) && ((y2_down && y2 >= min_y2));
+			-> b0 on ((!x2_down && !x2_up)) && ((!y2_down && !y2_up));
+			-> b0 on ((!x2_down && !x2_up)) && ((y2_up && y2 < max2_y2));
+			-> b0 on ((x2_up && x2 < max2_x2)) && ((y2_down && y2 >= min_y2));
+			-> b0 on ((x2_up && x2 < max2_x2)) && ((!y2_down && !y2_up));
+			-> b0 on ((x2_up && x2 < max2_x2)) && ((y2_up && y2 < max2_y2));
+			-> violation on (x2_down && x2 <= min_x2) recover x2_down:= 0;
+			-> violation on (x2_up && x2 >= max2_x2) recover x2_up:= 0;
+			-> violation on (y2_down && y2 <= min_y2) recover y2_down:= 0;
+			-> violation on (y2_up && y2 >= max2_y2) recover y2_up:= 0;
+		}
+
+	}
+}
+
+policy pj2 of pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd {
+	internals {
+		constant uint8_t threshold2 := 5; 
+		constant uint8_t pj_min_y2 := 200; 
+		dtimer_t v2;
+	}
+
+	states {
+        
+		l0 {
+			-> l0 on (!x2_up && !y2_up && !rpm2_up);
+			-> l1 on (x2_up || y2_up || rpm2_up): v2 := 0;
+		}
+
+		l1 {
+			-> l1 on (x2_up || x2_down || y2_up || (y2_down && v2 <= threshold2) || rpm2_up || rpm2_down): v2 := 0;
+			-> l1 on (!x2_up && !x2_down && !y2_up && !y2_down && v2 <= threshold2 && !rpm2_up && !rpm2_down);
+			-> l2 on (y2_down && v2 > threshold2);
+			-> violation on (v2 > threshold2) recover y2_down := 1;
+		}
+
+		l2 {
+			-> l2 on (y2_down && y2 > pj_min_y2);
+			-> violation on (!y2_down && y2 > pj_min_y2) recover y2_down := 1;
+			-> l0 on (y2 <= pj_min_y2);
+		}
+
+	}
+}
+
+policy pr2 of pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd {
+	internals {
+		constant uint16_t max2_rpm2 := 7825; 
+	}
+	states {
+        
+		r0 {
+			-> r0 on ((rpm2_up && rpm2 >= max2_rpm2));
+			-> r0 on ((!rpm2_up || rpm2_down));
+			-> violation on (rpm2_up && x2 >= max2_rpm2) recover rpm2_up := 0;
+			-> violation on ((rpm2_up && rpm2_down)) recover rpm2_up := 0;
+		}
+
+	}
+}
+
+
+policy pd of pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd {
+	internals {
+		constant uint8_t min_x_d2 := 3; 
+		constant uint8_t max_x_d1 := 2; 
+	}
+	states {
+        
+		b0 {
+			-> b0 on (!(x2 <= min_x_d2) || !(x >= max_x_d1));
+			-> b0 on (((x2 <= min_x_d2) && (x >= max_x_d1)) && (!x_down && x2_up));
+			-> b0 on (((x2 <= min_x_d2) && (x >= max_x_d1)) && (x_down && !x2_up));
+			-> b0 on (((x2 <= min_x_d2) && (x >= max_x_d1)) && (x_down && x2_up));
+			-> violation on (((x2 <= min_x_d2) && (x >= max_x_d1)) && (!x_down && !x2_up)) recover x_down:= 1;
+		}
+
+	}
+}

--- a/example/incrementalDrones/pd.erte
+++ b/example/incrementalDrones/pd.erte
@@ -1,0 +1,25 @@
+function pd;
+interface of pd {
+	in uint8_t x, y, x2, y2;
+	in uint16_t rpm, rpm2;
+	out uint8_t x_up, x_down, y_up, y_down, rpm_up, rpm_down; //out here means that they're going from CONTROLLER to PLANT
+	out uint8_t x2_up, x2_down, y2_up, y2_down, rpm2_up, rpm2_down;
+}
+
+policy pd of pd {
+	internals {
+		constant uint8_t min_x_d2 := 3; 
+		constant uint8_t max_x_d1 := 2; 
+	}
+	states {
+        
+		b0 {
+			-> b0 on (!(x2 <= min_x_d2) || !(x >= max_x_d1));
+			-> b0 on (((x2 <= min_x_d2) && (x >= max_x_d1)) && (!x_down && x2_up));
+			-> b0 on (((x2 <= min_x_d2) && (x >= max_x_d1)) && (x_down && !x2_up));
+			-> b0 on (((x2 <= min_x_d2) && (x >= max_x_d1)) && (x_down && x2_up));
+			-> violation on (((x2 <= min_x_d2) && (x >= max_x_d1)) && (!x_down && !x2_up)) recover x_down:= 1;
+		}
+
+	}
+}

--- a/example/incrementalDrones/series_pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd_main.c
+++ b/example/incrementalDrones/series_pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd_main.c
@@ -1,0 +1,94 @@
+#include "series_F_pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd.h"
+#include <stdio.h>
+
+#include "save_results.h"
+#include <time.h>
+#define RUN_REFERENCE "series_pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd"
+
+void print_data(uint32_t count, inputs_pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd_t inputs, outputs_pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd_t outputs) {
+    // printf("Tick %7d: x:%d, x_up:%d, x_down:%d, y:%d, y_up:%d, y_down:%d, z:%d, z_up:%d, z_down:%d, rpm:%d, rpm_up:%d, rpm_down:%d, x2:%d, x2_up:%d, x2_down:%d\r\n", count, inputs.x, outputs.x_up, outputs.x_down, inputs.y, outputs.y_up, outputs.y_down, inputs.z, outputs.z_up, outputs.z_down, inputs.rpm, outputs.rpm_up, outputs.rpm_down, inputs.x2, outputs.x2_up, outputs.x2_down);
+}
+
+int main() {
+    char run_reference[] = RUN_REFERENCE;
+    save_setup(run_reference);
+
+    double cpu_time_used[RUNS] = {0};
+    double cpu_time_ms_per_tick[RUNS] = {0};
+
+    for (uint16_t run = 0; run < RUNS; run++) {
+        clock_t start, end;
+
+        start = clock();
+        enforcervars_pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd_t enf;
+        inputs_pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd_t inputs;
+        outputs_pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd_t outputs;
+        
+        pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd_init_all_vars(&enf, &inputs, &outputs);
+
+        uint32_t count = 0;
+
+        // Drone 1 
+        //  min x = 0
+        //  max x = 2
+        //  min y = 200
+        //  max y = 202
+        //  rpm max = 7825
+
+        // Drone 2 
+        //  min x = 3
+        //  max x = 5
+        //  min y = 200
+        //  max y = 202
+        //  rpm max = 7825
+
+        // Initalise to maximums 
+        // controller will attempt to continue to increase beyond limits
+        // incremental enforcers will prevent limitation breaches
+        inputs.x = 0;
+        inputs.y = 200;
+        inputs.rpm = 7825;
+        inputs.x2 = 3;
+        inputs.y2 = 200;
+        inputs.rpm2 = 7825;
+
+        // print_data(0, inputs, outputs);
+        while(count++ < TICKS_PER_RUN) {
+            // inputs.x = inputs.x + 1;
+            outputs.x_up = true;
+            outputs.x_down = true;
+            // inputs.y = inputs.y + 1;
+            outputs.y_up = true;
+            outputs.y_down = true;
+            // inputs.rpm = inputs.rpm + 100;
+            outputs.rpm_up = true;
+            outputs.rpm_down = true;
+            // inputs.x2 = inputs.x2 + 1;
+            outputs.x2_up = true;
+            outputs.x2_down = true;
+            // inputs.y2 = inputs.y2 + 1;
+            outputs.y2_up = true;
+            outputs.y2_down = true;
+            // inputs.rpm2 = inputs.rpm2 + 100;
+            outputs.rpm2_up = true;
+            outputs.rpm2_down = true;
+
+            pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd_run_via_enforcer(&enf, &inputs, &outputs);
+
+            // print_data(count, inputs, outputs);
+        }
+        
+        end = clock();
+        cpu_time_used[run] = ((double) (end - start)) / CLOCKS_PER_SEC;
+        cpu_time_ms_per_tick[run] = (cpu_time_used[run] * 1000.0) / ((double) TICKS_PER_RUN);
+
+        save_time(run+1, cpu_time_used[run], cpu_time_ms_per_tick[run]);
+
+        printf("Run: %d, CPU: %.0f ms, Per Tick: %f ms\n", run+1, cpu_time_used[run]*1000, cpu_time_ms_per_tick[run]);
+    }   
+}
+
+void pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd_run(inputs_pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd_t *inputs, outputs_pb_and_ps_and_pj_and_pr_and_pb2_and_ps2_and_pj2_and_pr2_and_pd_t *outputs) {
+    //do nothing
+}
+

--- a/example/incrementalDrones/series_pd_main.c
+++ b/example/incrementalDrones/series_pd_main.c
@@ -1,0 +1,82 @@
+#include "series_F_pd.h"
+#include <stdio.h>
+
+#include "save_results.h"
+#include <time.h>
+#define RUN_REFERENCE "series_pd"
+
+void print_data(uint32_t count, inputs_pd_t inputs, outputs_pd_t outputs) {
+    printf("Tick %7d: x:%d, x_up:%d, x_down:%d, y:%d, y_up:%d, y_down:%d, rpm:%d, rpm_up:%d, rpm_down:%d, x2:%d, x2_up:%d, x2_down:%d\r\n", count, inputs.x, outputs.x_up, outputs.x_down, inputs.y, outputs.y_up, outputs.y_down, inputs.rpm, outputs.rpm_up, outputs.rpm_down, inputs.x2, outputs.x2_up, outputs.x2_down);
+}
+
+int main() {
+    char run_reference[] = RUN_REFERENCE;
+    save_setup(run_reference);
+
+    double cpu_time_used[RUNS] = {0};
+    double cpu_time_ms_per_tick[RUNS] = {0};
+
+    for (uint16_t run = 0; run < RUNS; run++) {
+        clock_t start, end;
+
+        start = clock();
+        enforcervars_pd_t enf;
+        inputs_pd_t inputs;
+        outputs_pd_t outputs;
+        
+        pd_init_all_vars(&enf, &inputs, &outputs);
+
+        uint32_t count = 0;
+
+        // Drone 1 
+        //  min x = 0
+        //  max x = 2
+        //  min y = 200
+        //  max y = 202
+        //  rpm max = 7825
+
+        // Drone 2 
+        //  min x = 3
+        //  max x = 5
+        //  min y = 200
+        //  max y = 202
+        //  rpm max = 7825
+
+        // Initalise to maximums 
+        // controller will attempt to continue to increase beyond limits
+        // incremental enforcers will prevent limitation breaches
+        inputs.x = 2;
+        inputs.y = 200;
+        inputs.rpm = 7825;
+
+        inputs.x2 = 3;
+        inputs.y2 = 200;
+        inputs.rpm2 = 7825;
+        // print_data(0, inputs, outputs);
+        while(count++ < TICKS_PER_RUN) {
+            // inputs.x = inputs.x + 1;
+            outputs.x_up = false;
+            outputs.x_down = false;
+
+            outputs.x2_up = false;
+            outputs.x2_down = false;
+
+            pd_run_via_enforcer(&enf, &inputs, &outputs);
+
+            print_data(count, inputs, outputs);
+        }
+        
+        end = clock();
+        cpu_time_used[run] = ((double) (end - start)) / CLOCKS_PER_SEC;
+        cpu_time_ms_per_tick[run] = (cpu_time_used[run] * 1000.0) / ((double) TICKS_PER_RUN);
+
+        save_time(run+1, cpu_time_used[run], cpu_time_ms_per_tick[run]);
+
+        printf("Run: %d, CPU: %.0f ms, Per Tick: %f ms\n", run+1, cpu_time_used[run]*1000, cpu_time_ms_per_tick[run]);
+    }   
+}
+
+void pd_run(inputs_pd_t *inputs, outputs_pd_t *outputs) {
+    //do nothing
+}
+


### PR DESCRIPTION
Drones 1 and 2 share a boundary at max x for drone 1 and min x for drone 2. When both drones are at this boundary, one and/or both should take evasive action to reduce the risk of collision. This can be considered similar to a safe distance policy. 

![image](https://user-images.githubusercontent.com/20588360/214947645-c9fc3a24-cfde-4831-8bc9-1e12cecce3c6.png)
